### PR TITLE
Added semi-automatic rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,5 +40,4 @@ window.addEventListener('keydown', function(e) {
     }
 }, true)
 
-// I don't know a good way to trigger rerender automatically yet
-//document.addEventListener('DOMContentLoaded', rerender_all, false);
+window.addEventListener('click', function() {rerender_all()}, true)


### PR DESCRIPTION
Added a semi-automatic rerender_all event listener for when you double click off a paragraph of interest. Behavior is still finicky: two separate code blocks can be unformatted at the same time upon clicking around + double clicking anywhere in the page body executes rerender_all yet it seems just single clicking in the sidebar also executes rerender_all.